### PR TITLE
fix(nvim): Implement ts_ls/denols mutual exclusion and migrate to vim.lsp.config

### DIFF
--- a/dot_config/nvim/lua/plugins.lua
+++ b/dot_config/nvim/lua/plugins.lua
@@ -90,6 +90,14 @@ return {
         event = { 'InsertEnter', 'CmdlineEnter' },
         dependencies = {
             'rafamadriz/friendly-snippets',
+            {
+                'L3MON4D3/LuaSnip',
+                version = 'v2.*',
+                build = 'make install_jsregexp',
+                config = function()
+                    require('luasnip.loaders.from_vscode').lazy_load()
+                end,
+            },
         },
         opts = {
             keymap = { preset = 'super-tab' },
@@ -97,7 +105,14 @@ return {
                 nerd_font_variant = 'mono',
             },
             completion = {
-                documentation = { auto_show = false },
+                documentation = { auto_show = true },
+                ghost_text = {
+                    enabled = true,
+                    show_with_menu = true,
+                },
+            },
+            snippets = {
+                preset = 'luasnip',
             },
             sources = {
                 default = { 'lsp', 'path', 'snippets', 'buffer' },


### PR DESCRIPTION
## Summary

This PR fixes the long-standing issue where both `ts_ls` and `denols` LSP servers were attaching to TypeScript files simultaneously, causing conflicts and degraded functionality.

## Changes

### Completion Engine Migration
- ✅ Switch from `coq_nvim` to `blink.cmp` for modern completion
- ✅ Add `LuaSnip` integration for snippet support
- ✅ Enable Ghost Text for inline completion suggestions

### LSP API Migration
- ✅ Migrate all LSP configurations from deprecated `lspconfig.setup()` to new `vim.lsp.config()` API
- ✅ Remove deprecation warnings for Neovim 0.11+
- ✅ Implement custom `root_pattern` helper using `vim.fs.find()`

### TypeScript/Deno LSP Mutual Exclusion
- ✅ Implement three-layer defense mechanism:
  1. **BufReadPost autocommand**: Sets allowed server flag early (before FileType)
  2. **FileType autocommand**: Manually starts the correct server with `vim.lsp.start()`
  3. **LspAttach autocommand**: Acts as kill switch, immediately stopping unwanted servers

### Behavior
- 🔹 **Deno projects** (with `deno.json`): Only `denols` attaches
- 🔹 **Node projects** (with `package.json`): Only `ts_ls` attaches
- 🔹 **Mixed projects**: No LSP server for TypeScript (prevents conflicts)

## Why This Approach?

The kill switch in `LspAttach` is defensive and failsafe - it catches unwanted servers regardless of what starts them (lspconfig autostart, mason-lspconfig handlers, or any other plugin).

## Testing

Tested on:
- ✅ Deno project: `~/sandbox/deno/deno-await.ts` → only `denols` attaches
- ✅ Node project: `~/ghq/github.com/iomz/javutil-ui/lib/email.ts` → only `ts_ls` attaches
- ✅ No deprecation warnings
- ✅ All LSP features working correctly

Closes #[issue_number] (if applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces mutual exclusion between ts_ls and denols, migrates LSP setup to vim.lsp.config with per-server configs and format-on-save, and upgrades completion with LuaSnip, auto docs, and ghost text.
> 
> - **LSP (vim.lsp.config migration)**
>   - Replace lspconfig handlers with explicit `vim.lsp.config(...)` per server (`gopls`, `lua_ls`, `pylsp`) and enable a set of simple servers (`ruff`, `dockerls`, `marksman`, `rust_analyzer`, `yamlls`, `eslint`, `tailwindcss`).
>   - Add `root_pattern` helper using `vim.fs.find` and per-server `root_markers`/settings.
>   - New `on_attach` with buffer keymaps and centralized format-on-save (skips Go); separate Go `goimports` on save.
>   - Implement `ts_ls`/`denols` mutual exclusion:
>     - `FileType` autocmd sets `_G.allowed_ts_server` and starts the correct server via `vim.lsp.start`.
>     - `LspAttach` kill-switch stops unwanted server; `BufDelete` cleans state.
> - **Completion (blink.cmp)**
>   - Add `LuaSnip` dependency and set snippets preset to `luasnip`.
>   - Enable auto documentation and inline `ghost_text` in completion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15a71d597235d600d548d2c02db6c94b8debc7d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VSCode-style snippet insertion in completions
  * Automatic completion documentation and inline ghost text
  * Per-project automatic selection and lifecycle management for TypeScript/JavaScript language servers

* **Improvements**
  * More explicit per-language server configurations for greater stability
  * Centralized, reliable format-on-save behavior
  * Enhanced diagnostics and Tailwind CSS support across projects
<!-- end of auto-generated comment: release notes by coderabbit.ai -->